### PR TITLE
Env var check for elasticapm

### DIFF
--- a/platform_out/app/__init__.py
+++ b/platform_out/app/__init__.py
@@ -32,7 +32,8 @@ def create_app(script_info=None):
 
     # set up extensions
     db.init_app(app)
-    elastic_apm.init_app(app)
+    if os.getenv("USE_ELASTIC"):
+        elastic_apm.init_app(app)
 
     # register blueprints
     with app.app_context():


### PR DESCRIPTION
Added fix only for elastic_apm instantiation - error logging needs to be done separately in a different branch. Now it is missing altogether.